### PR TITLE
feat:(3) 스프링 배치를 통해 이벤트를 주기적으로 업데이트 할 수 있다.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,6 +37,15 @@ dependencies {
 	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
 	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
 	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+
+	implementation 'org.springframework.boot:spring-boot-starter-batch'
+	implementation 'com.squareup.okhttp3:okhttp'
+	runtimeOnly 'org.mariadb.jdbc:mariadb-java-client'
+	annotationProcessor "com.querydsl:querydsl-apt:5.0.0:jakarta"
+	annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+	annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+	implementation 'org.springframework.boot:spring-boot-configuration-processor'
+
 }
 
 tasks.named('test') {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,7 @@ services:
       - fbook
 
 
-#   스프링 로컬로 실행 시 주석 처리하고 DB만 도커 빌드
+  #   스프링 로컬로 실행 시 주석 처리하고 DB만 도커 빌드
   springboot:
     build:
       context: .
@@ -39,5 +39,4 @@ services:
 networks:
   fbook:
     driver: bridge
-
 

--- a/src/main/java/com/festibook/festibook_backend/FestibookBackendApplication.java
+++ b/src/main/java/com/festibook/festibook_backend/FestibookBackendApplication.java
@@ -2,8 +2,10 @@ package com.festibook.festibook_backend;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+@EnableScheduling
 @SpringBootApplication
 @EnableJpaAuditing
 public class FestibookBackendApplication {

--- a/src/main/java/com/festibook/festibook_backend/configuration/ApplicationContextProvider.java
+++ b/src/main/java/com/festibook/festibook_backend/configuration/ApplicationContextProvider.java
@@ -1,0 +1,21 @@
+package com.festibook.festibook_backend.configuration;
+
+import org.springframework.beans.BeansException;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.ApplicationContextAware;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ApplicationContextProvider implements ApplicationContextAware {
+
+  private static ApplicationContext applicationContext;
+
+  public static <T> T getBean(String name, Class<T> requiredType) {
+    return applicationContext.getBean(name, requiredType);
+  }
+
+  @Override
+  public void setApplicationContext(ApplicationContext applicationContext) throws BeansException {
+    ApplicationContextProvider.applicationContext = applicationContext;
+  }
+}

--- a/src/main/java/com/festibook/festibook_backend/configuration/OkhttpConfiguration.java
+++ b/src/main/java/com/festibook/festibook_backend/configuration/OkhttpConfiguration.java
@@ -1,0 +1,14 @@
+package com.festibook.festibook_backend.configuration;
+
+import okhttp3.OkHttpClient;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class OkhttpConfiguration {
+
+  @Bean
+  public OkHttpClient okHttpClient() {
+    return new OkHttpClient.Builder().build();
+  }
+}

--- a/src/main/java/com/festibook/festibook_backend/configuration/OpenApiProperty.java
+++ b/src/main/java/com/festibook/festibook_backend/configuration/OpenApiProperty.java
@@ -1,0 +1,21 @@
+package com.festibook.festibook_backend.configuration;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Component
+@ConfigurationProperties("open-api")
+@Getter
+@Setter
+public class OpenApiProperty {
+
+  private EventApi eventApi;
+
+  @Getter
+  @Setter
+  public static class EventApi {
+    private String url;
+  }
+}

--- a/src/main/java/com/festibook/festibook_backend/core/exception/OkhttpException.java
+++ b/src/main/java/com/festibook/festibook_backend/core/exception/OkhttpException.java
@@ -1,0 +1,11 @@
+package com.festibook.festibook_backend.core.exception;
+
+import lombok.Getter;
+
+@Getter
+public class OkhttpException extends RuntimeException {
+
+  public OkhttpException(String message) {
+    super(message);
+  }
+}

--- a/src/main/java/com/festibook/festibook_backend/core/util/OkhttpJsonRequest.java
+++ b/src/main/java/com/festibook/festibook_backend/core/util/OkhttpJsonRequest.java
@@ -1,0 +1,25 @@
+package com.festibook.festibook_backend.core.util;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.Map;
+import org.springframework.http.HttpMethod;
+
+public class OkhttpJsonRequest extends OkhttpRequest {
+
+  private static final ObjectMapper objectMapper = new ObjectMapper();
+
+  public OkhttpJsonRequest(String url, Object request, HttpMethod httpMethod) {
+    super(OkhttpMediaType.JSON, url, request, httpMethod);
+  }
+
+  @Override
+  public String convertRequestToString() {
+    try {
+      return objectMapper.writeValueAsString(request);
+    } catch (JsonProcessingException e) {
+      return null;
+    }
+  }
+}
+

--- a/src/main/java/com/festibook/festibook_backend/core/util/OkhttpRequest.java
+++ b/src/main/java/com/festibook/festibook_backend/core/util/OkhttpRequest.java
@@ -1,0 +1,94 @@
+package com.festibook.festibook_backend.core.util;
+
+import com.festibook.festibook_backend.configuration.ApplicationContextProvider;
+import com.festibook.festibook_backend.core.exception.OkhttpException;
+import java.io.IOException;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import okhttp3.MediaType;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.RequestBody;
+import okhttp3.Response;
+import okhttp3.ResponseBody;
+import org.springframework.http.HttpMethod;
+
+@Slf4j
+@Getter
+@RequiredArgsConstructor
+public abstract class OkhttpRequest {
+
+  private static final OkHttpClient client = ApplicationContextProvider.getBean("okHttpClient",
+      OkHttpClient.class);
+
+  protected final OkhttpMediaType mediaType;
+
+  protected final String url;
+
+  protected final Object request;
+
+  protected final HttpMethod httpMethod;
+
+
+  public abstract String convertRequestToString();
+
+  private MediaType getMediaType() {
+    return MediaType.parse(this.mediaType.getType());
+  }
+
+  public Response request() {
+    Response response = null;
+    StringBuilder logStringBuilder = new StringBuilder();
+    RequestBody requestBody = RequestBody.create(convertRequestToString(), getMediaType());
+    Request.Builder requestBuilder = new Request.Builder().url(this.url);
+
+    if (this.httpMethod == HttpMethod.GET) {
+      requestBuilder.method(this.httpMethod.name(), null);
+    } else {
+      requestBuilder.method(this.httpMethod.name(), requestBody);
+    }
+    Request request = requestBuilder.build();
+    try {
+      response = client.newCall(request)
+          .execute();
+
+      logStringBuilder.append("Request Url : ");
+      logStringBuilder.append(this.url);
+      log.info(logStringBuilder.toString());
+    } catch (IOException e) {
+      logStringBuilder.append("[Okhttp Request Fail]");
+      logStringBuilder.append("Request Url : ");
+      logStringBuilder.append(this.url);
+      log.error(logStringBuilder.toString());
+      throw new OkhttpException(e.getMessage());
+    }
+    ResponseBody responseBody = response.body();
+    if (responseBody == null || !response.isSuccessful()) {
+      logStringBuilder.append("\n");
+      logStringBuilder.append("[Okhttp Response Fail]");
+      if (responseBody != null) {
+        try {
+          logStringBuilder.append("Response Body : ");
+          logStringBuilder.append(response.peekBody(Long.MAX_VALUE)
+              .string());
+        } catch (IOException e) {
+          log.error("[OkhttpRequest] Read Response Body Has Error ", e);
+        }
+      }
+      log.error(logStringBuilder.toString());
+      return response;
+    }
+    return response;
+  }
+
+  @RequiredArgsConstructor
+  @Getter
+  protected enum OkhttpMediaType {
+    XML("text/xml; charset=utf-8"), JSON("application/json; charset=utf-8");
+
+    private final String type;
+  }
+}
+
+

--- a/src/main/java/com/festibook/festibook_backend/event/batch/CacheEventJob.java
+++ b/src/main/java/com/festibook/festibook_backend/event/batch/CacheEventJob.java
@@ -1,0 +1,79 @@
+package com.festibook.festibook_backend.event.batch;
+
+
+import com.festibook.festibook_backend.event.entity.Event;
+import com.festibook.festibook_backend.event.repository.EventRepository;
+import com.festibook.festibook_backend.event.useCase.CacheEventUseCase;
+import com.festibook.festibook_backend.event.useCase.CacheEventUseCase.CacheEventRequest;
+import com.festibook.festibook_backend.event.useCase.CacheEventUseCase.CacheEventResponse;
+import com.festibook.festibook_backend.external.event.dto.EventResponse.Item;
+import jakarta.annotation.PostConstruct;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.Scheduled;
+
+@Log4j2
+@RequiredArgsConstructor
+@Configuration
+public class CacheEventJob {
+
+  private final CacheEventUseCase cacheEventUseCase;
+
+  private final EventRepository eventRepository;
+
+  @PostConstruct
+  @Scheduled(cron = "0 0 1 * * *")
+  public void CacheEventJobScheduler() {
+    LocalDate currentDate = LocalDate.now();
+    DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyyMMdd");
+    String formattedDate = currentDate.format(formatter);
+
+    CacheEventResponse cacheEventResponse = cacheEventUseCase.execute(CacheEventRequest.builder()
+        .eventStartDate(formattedDate)
+        .build());
+
+    List<Item> items = cacheEventResponse.getItems();
+    List<Event> events = new ArrayList<>();
+    for (Item item : items) {
+      Optional<Event> existingEvent = eventRepository.findByContentId(item.getContentid());
+      if (existingEvent.isPresent()) {
+        Event eventToUpdate = existingEvent.get();
+        updateEvent(eventToUpdate, item);
+        events.add(eventToUpdate);
+      } else {
+        events.add(createEvent(item));
+      }
+    }
+
+    eventRepository.saveAll(events);
+  }
+
+  private void updateEvent(Event event, Item item) {
+    event.setTitle(item.getTitle());
+    event.setAddress1(item.getAddr1());
+    event.setAddress2(item.getAddr2());
+    event.setOriginUrl(item.getFirstimage());
+    event.setThumbnailUrl(item.getFirstimage2());
+    event.setMapX(item.getMapx());
+    event.setMapY(item.getMapy());
+  }
+
+  private Event createEvent(Item item) {
+    return Event.builder()
+        .contentId(item.getContentid())
+        .title(item.getTitle())
+        .address1(item.getAddr1())
+        .address2(item.getAddr2())
+        .originUrl(item.getFirstimage())
+        .thumbnailUrl(item.getFirstimage2())
+        .mapX(item.getMapx())
+        .mapY(item.getMapy())
+        .build();
+  }
+}

--- a/src/main/java/com/festibook/festibook_backend/event/entity/Event.java
+++ b/src/main/java/com/festibook/festibook_backend/event/entity/Event.java
@@ -1,0 +1,35 @@
+package com.festibook.festibook_backend.event.entity;
+
+import com.festibook.festibook_backend.core.BaseEntity;
+import jakarta.persistence.Entity;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.experimental.SuperBuilder;
+
+@Getter
+@Setter
+@SuperBuilder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+public class Event extends BaseEntity {
+
+    private int contentId;
+
+    private String title;
+
+    private String address1;
+
+    private String address2;
+
+    private String originUrl;
+
+    private String thumbnailUrl;
+
+    private double mapX;
+
+    private double mapY;
+}

--- a/src/main/java/com/festibook/festibook_backend/event/repository/EventRepository.java
+++ b/src/main/java/com/festibook/festibook_backend/event/repository/EventRepository.java
@@ -1,0 +1,10 @@
+package com.festibook.festibook_backend.event.repository;
+
+import com.festibook.festibook_backend.event.entity.Event;
+import java.util.Optional;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface EventRepository extends JpaRepository<Event, UUID> {
+  Optional<Event> findByContentId(int contentId);
+}

--- a/src/main/java/com/festibook/festibook_backend/event/useCase/CacheEventUseCase.java
+++ b/src/main/java/com/festibook/festibook_backend/event/useCase/CacheEventUseCase.java
@@ -1,0 +1,99 @@
+package com.festibook.festibook_backend.event.useCase;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.festibook.festibook_backend.configuration.OpenApiProperty;
+import com.festibook.festibook_backend.core.util.OkhttpJsonRequest;
+import com.festibook.festibook_backend.external.event.dto.EventResponse;
+import com.festibook.festibook_backend.external.event.dto.EventResponse.Item;
+import java.util.List;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+import lombok.experimental.SuperBuilder;
+import lombok.extern.log4j.Log4j2;
+import okhttp3.Response;
+import org.springframework.http.HttpMethod;
+import org.springframework.stereotype.Service;
+
+@Log4j2
+@RequiredArgsConstructor
+@Service
+public class CacheEventUseCase {
+
+  private final OpenApiProperty openApiProperty;
+
+  private final ObjectMapper objectMapper = new ObjectMapper().configure(
+      DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+
+  public CacheEventResponse execute(CacheEventRequest request) {
+    OkhttpJsonRequest okhttpJsonRequest = toJsonRequest(request);
+    Response response = okhttpJsonRequest.request();
+    EventResponse eventResponse = null;
+    try {
+      eventResponse = objectMapper.readValue(response.body().string(), EventResponse.class);
+    } catch (Exception e) {
+      throw new RuntimeException("Failed to create OkhttpJsonRequest", e);
+    }
+    return CacheEventResponse.builder()
+        .items(eventResponse.getResponse().getBody().getItems().getItem())
+        .build();
+  }
+
+  private CacheEventRequest toResult(Response response) {
+    return CacheEventRequest.builder().build();
+  }
+
+  public OkhttpJsonRequest toJsonRequest(CacheEventRequest request) {
+    if (openApiProperty == null || openApiProperty.getEventApi() == null
+        || openApiProperty.getEventApi().getUrl() == null) {
+      return null;
+    }
+    String queryString = "?numOfRows=50"
+        + "&pageNo=1"
+        + "&MobileOS=ETC"
+        + "&MobileApp=AppTest"
+        + "&_type=json"
+        + "&listYN=Y"
+        + "&arrange=A"
+        + "&eventStartDate="
+        + request.getEventStartDate()
+        + "&serviceKey=";
+    try {
+      OkhttpJsonRequest okhttpJsonRequest = new OkhttpJsonRequest(
+          openApiProperty.getEventApi().getUrl() + queryString, null, HttpMethod.GET);
+      System.out.println("Request created successfully: " + request);
+      return okhttpJsonRequest;
+    } catch (Exception e) {
+      throw new RuntimeException("Failed to create OkhttpJsonRequest", e);
+    }
+
+  }
+
+  @ToString
+  @Getter
+  @Setter
+  @SuperBuilder
+  @NoArgsConstructor(access = AccessLevel.PRIVATE)
+  public static class CacheEventResponse {
+
+    List<Item> items;
+  }
+
+  @ToString
+  @Getter
+  @Setter
+  @Builder
+  @NoArgsConstructor(access = AccessLevel.PRIVATE)
+  @AllArgsConstructor(access = AccessLevel.PRIVATE)
+  public static class CacheEventRequest {
+
+    private String eventStartDate;
+  }
+
+}

--- a/src/main/java/com/festibook/festibook_backend/external/event/dto/EventRequest.java
+++ b/src/main/java/com/festibook/festibook_backend/external/event/dto/EventRequest.java
@@ -1,0 +1,36 @@
+package com.festibook.festibook_backend.external.event.dto;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+
+@ToString
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class EventRequest {
+
+  private int numOfRows;
+
+  private int pageNo;
+
+  private String MobileOS;
+
+  private String MobileApp;
+
+  private String _type;
+
+  private String listYN;
+
+  private String arrange;
+
+  private String eventStartDate;
+
+  private String serviceKey;
+}

--- a/src/main/java/com/festibook/festibook_backend/external/event/dto/EventResponse.java
+++ b/src/main/java/com/festibook/festibook_backend/external/event/dto/EventResponse.java
@@ -1,0 +1,74 @@
+package com.festibook.festibook_backend.external.event.dto;
+
+import java.util.List;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+
+@ToString
+@Getter
+public class EventResponse {
+  private Response response;
+
+  @ToString
+  @Getter
+  @Setter
+  public static class Response {
+    private Header header;
+    private Body body;
+  }
+
+  @ToString
+  @Getter
+  @Setter
+  public static class Header {
+    private String resultCode;
+    private String resultMsg;
+  }
+
+  @ToString
+  @Getter
+  @Setter
+  public static class Body {
+    private Items items;
+    private int numOfRows;
+    private int pageNo;
+    private int totalCount;
+  }
+
+  @ToString
+  @Getter
+  @Setter
+  public static class Items {
+    private List<Item> item;
+  }
+
+  @ToString
+  @Getter
+  @Setter
+  public static class Item {
+    private String addr1;
+    private String addr2;
+    private String booktour;
+    private String cat1;
+    private String cat2;
+    private String cat3;
+    private Integer contentid;
+    private Integer contenttypeid;
+    private String createdtime;
+    private String eventstartdate;
+    private String eventenddate;
+    private String firstimage;
+    private String firstimage2;
+    private String cpyrhtDivCd;
+    private Double mapx;
+    private Double mapy;
+    private Integer mlevel;
+    private String modifiedtime;
+    private String areacode;
+    private String sigungucode;
+    private String tel;
+    private String title;
+  }
+}
+

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -75,3 +75,7 @@ jwt:
     refresh-expire-length: 604800000 # 7일
 
 
+
+open-api:
+  event-api:
+    url: http://apis.data.go.kr/B551011/KorService1/searchFestival1


### PR DESCRIPTION
## Summary
하루에 한번 [행사정보조회 open API](https://api.visitkorea.or.kr/#/useKoreaGuide) 요청을 보내 필요한 행사 데이터를 저장합니다.

## Description
- spring batch를 통해 하루에 한번 api 실행합니다. (초기 실행 시 한번은 돌아가게 작업해두었습니다.)
- 실행 전에 `CacheEventUseCase`의 64번째 줄에 serviceKey를 추가해야합니다. (slack 공유 예정)
- 현재는 개발 단계로 50개의 데이터만 받아오도록 하였습니다. (추후 배포 시 수정해야합니다)

## Screenshots
<img width="862" alt="image" src="https://github.com/user-attachments/assets/37dfedd6-bb29-4694-8d8a-63ff2dfd4f4c">


## Test Checklist
- [ ] 실행 후 event 테이블에 값들이 들어가는지 확인
